### PR TITLE
Strip spaces from private key

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    eyaml (0.1.1)
+    eyaml (0.1.2)
       rbnacl (~> 7.1)
       thor (~> 1.1)
 

--- a/lib/eyaml/encryption_manager.rb
+++ b/lib/eyaml/encryption_manager.rb
@@ -18,8 +18,8 @@ module EYAML
 
     def initialize(yaml, public_key, private_key = nil)
       @tree = yaml
-      @public_key = EYAML::Util.ensure_binary_encoding(public_key)
-      @private_key = private_key.nil? ? nil : EYAML::Util.ensure_binary_encoding(private_key)
+      @public_key = RbNaCl::Util.hex2bin(public_key)
+      @private_key = private_key && RbNaCl::Util.hex2bin(private_key.strip)
     end
 
     def decrypt

--- a/lib/eyaml/util.rb
+++ b/lib/eyaml/util.rb
@@ -6,14 +6,6 @@ module EYAML
       def pretty_yaml(some_hash)
         some_hash.to_yaml.delete_prefix("---\n")
       end
-
-      def ensure_binary_encoding(str)
-        if str.encoding == Encoding::BINARY
-          return str
-        end
-
-        RbNaCl::Util.hex2bin(str)
-      end
     end
   end
 end

--- a/lib/eyaml/version.rb
+++ b/lib/eyaml/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EYAML
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end

--- a/spec/eyaml/encrypted_manager_spec.rb
+++ b/spec/eyaml/encrypted_manager_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe EYAML::EncryptionManager do
       expect(priv_key.encoding).to be Encoding::ASCII
     end
   end
-
   subject do
     EYAML::EncryptionManager.new(data, public_key, private_key)
   end
@@ -47,6 +46,11 @@ RSpec.describe EYAML::EncryptionManager do
 
     it "doesn't touch values with an underscore in their key" do
       expect(subject.decrypt).to include("_secret" => data["_secret"])
+    end
+
+    it "accepts a private key with trailing newline" do
+      manager = EYAML::EncryptionManager.new(data, public_key, "#{private_key}\n")
+      expect { manager.decrypt }.not_to raise_error
     end
 
     context "invalid EJSON format version" do

--- a/spec/eyaml/util_spec.rb
+++ b/spec/eyaml/util_spec.rb
@@ -7,18 +7,4 @@ RSpec.describe EYAML::Util do
       expect(EYAML::Util.pretty_yaml({"a" => "1", "b" => "2"})).to eq(yaml_without_prefix)
     end
   end
-
-  describe ".ensure_binary_encoding" do
-    let(:utf_8_string) { "abc" }
-    let(:binary_string) { "\xAB\xC0".b }
-
-    it "returns a string in binary encoding" do
-      expect(EYAML::Util.ensure_binary_encoding(utf_8_string)).to eq(binary_string)
-      expect(EYAML::Util.ensure_binary_encoding(utf_8_string).encoding).to eq(Encoding::BINARY)
-    end
-
-    it "returns the provided string if it's already binary encoded" do
-      expect(EYAML::Util.ensure_binary_encoding(binary_string)).to eq(binary_string)
-    end
-  end
 end

--- a/spec/support/custom_matchers.rb
+++ b/spec/support/custom_matchers.rb
@@ -33,7 +33,7 @@ end
 
 RSpec::Matchers.define :be_public_key_of do |priv_key|
   match do |pub_key|
-    priv_key_bin = EYAML::Util.ensure_binary_encoding(priv_key)
+    priv_key_bin = RbNaCl::Util.hex2bin(priv_key)
     private_key = RbNaCl::Boxes::Curve25519XSalsa20Poly1305::PrivateKey.new(priv_key_bin)
 
     public_key_hex = RbNaCl::Util.bin2hex(private_key.public_key)


### PR DESCRIPTION
The private key file sometimes contains a newline. We should strip spaces so those files are interpreted correctly.

I also changed it so EncryptionManager only accepts hex-encoded keys, since it only returns hex-encoded keys from new_keypair as well. Not sure what the binary strip support was used for (doesn't seem to be a test for it).