### PR TITLE
Use string keys for aliases

### DIFF
--- a/lib/eyaml/cli.rb
+++ b/lib/eyaml/cli.rb
@@ -56,9 +56,9 @@ module EYAML
       puts "Private Key: #{private_key}" unless options.fetch(:write)
     end
 
-    map e: :encrypt
-    map d: :decrypt
-    map g: :keygen
+    map "e" => "encrypt"
+    map "d" => "decrypt"
+    map "g" => "keygen"
 
     def self.exit_on_failure?
       true


### PR DESCRIPTION
It seems symbols don't work for this (any more?) https://www.rubydoc.info/github/wycats/thor/master/Thor#map-class_method

It raises an exception if you do `eyaml e`