### PR TITLE
Improve readme and add warning on rails credentials conflict

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,9 @@ GEM
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
     crass (1.0.6)
+    debug (1.9.2)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
     diff-lcs (1.5.0)
     drb (2.2.0)
       ruby2_keywords
@@ -126,6 +129,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  debug
   eyaml!
   fakefs
   ffi (~> 1.15.5)

--- a/eyaml.gemspec
+++ b/eyaml.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency("rake", "~> 13.0")
   spec.add_development_dependency("rspec", "~> 3.0")
+  spec.add_development_dependency("debug")
 end

--- a/lib/eyaml/railtie.rb
+++ b/lib/eyaml/railtie.rb
@@ -8,7 +8,13 @@ module EYAML
     class Railtie < Rails::Railtie
       PRIVATE_KEY_ENV_VAR = "EJSON_PRIVATE_KEY"
 
+      class ConflictError < StandardError
+      end
+
       config.before_configuration do
+        if File.exist?(Rails.root.join("config", "master.key"))
+          raise ConflictError, "A config/master.key has been found. The rails credentials lookup conflicts with eyaml. Please remove rails credentials management by removing the master.key file to keep using eyaml."
+        end
         secret_files_present = Dir.glob(auth_files(:secrets)).any?
         credential_files_present = Dir.glob(auth_files(:credentials)).any?
 

--- a/spec/eyaml/railtie_spec.rb
+++ b/spec/eyaml/railtie_spec.rb
@@ -37,6 +37,20 @@ RSpec.describe(EYAML::Rails::Railtie) do
         allow_rails.to(receive_message_chain("application.credentials").and_return(credentials))
       end
 
+      after do
+        if File.exist?(config_root.join("master.key"))
+          File.delete(config_root.join("master.key"))
+        end
+      end
+
+      it "raises when a master.key file is present" do
+        run_load_hooks
+        expect(credentials).to(include(:secret))
+
+        File.write(config_root.join("master.key"), "test")
+        expect { run_load_hooks }.to raise_error(EYAML::Rails::Railtie::ConflictError)
+      end
+
       it "merges credentials into application credentials" do
         run_load_hooks
         expect(credentials).to(include(:secret))


### PR DESCRIPTION
Eyaml doesn't work with the new rails' credentials encryption (they both do the same thing in principle). The rails credentials management relies on a `.yml.enc`file which is encrypted via a key present in the master.key file (which is 32 bytes). Eyaml uses it own key which is 64 bytes in fact. I've improved the readme for general eyaml config/installation and added a raise when a master/key file is present.