### PR TITLE
Don't load eyaml when SECRET_KEY_BASE_DUMMY env var is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ Instead of needing a private key locally, you can provide it to EYAML by setting
 
 If you put your rails master key encrypted in the eyaml file, make sure you don't have another `master.key` file somewhere, since that can interfere.
 
+When setting the SECRET_KEY_BASE_DUMMY environment variable, the secrets/credentials loading will be skipped.
+This can be handy to for example do an asset precompilation step in production where you don't need any secrets/credentials.
+
 ### Example setup
 
 To add encryption + credentials to a rails project do the following things:

--- a/lib/eyaml/version.rb
+++ b/lib/eyaml/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EYAML
-  VERSION = "0.4.3"
+  VERSION = "0.4.4"
 end

--- a/spec/eyaml/railtie_spec.rb
+++ b/spec/eyaml/railtie_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe(EYAML::Rails::Railtie) do
     let(:credentials) { credentials_class.new }
 
     before(:each) do
+      ENV.delete("SECRET_KEY_BASE_DUMMY")
+
       FakeFS::FileSystem.clone(fixtures_root)
 
       supported_extensions.each do |ext|
@@ -41,6 +43,12 @@ RSpec.describe(EYAML::Rails::Railtie) do
         if File.exist?(config_root.join("master.key"))
           File.delete(config_root.join("master.key"))
         end
+      end
+
+      it "does not try to load credentials when SECRET_KEY_BASE_DUMMY env var is set" do
+        ENV["SECRET_KEY_BASE_DUMMY"] = "1"
+        expect { run_load_hooks }.not_to raise_error
+        expect(credentials).to(be_empty)
       end
 
       it "raises when a master.key file is present" do
@@ -147,6 +155,8 @@ RSpec.describe(EYAML::Rails::Railtie) do
     let(:secrets) { secrets_class.new }
 
     before(:each) do
+      ENV.delete("SECRET_KEY_BASE_DUMMY")
+
       FakeFS::FileSystem.clone(fixtures_root)
 
       supported_extensions.each do |ext|
@@ -166,6 +176,12 @@ RSpec.describe(EYAML::Rails::Railtie) do
       before do
         allow_rails.to(receive(:root).and_return(fixtures_root))
         allow_rails.to(receive_message_chain("application.secrets").and_return(secrets))
+      end
+
+      it "does not try to load secrets when SECRET_KEY_BASE_DUMMY env var is set" do
+        ENV["SECRET_KEY_BASE_DUMMY"] = "1"
+        expect { run_load_hooks }.not_to raise_error
+        expect(secrets).to(be_empty)
       end
 
       it "merges secrets into application secrets" do


### PR DESCRIPTION
Since rails can run asset precompilation in production without having a master key set by setting SECRET_KEY_BASE_DUMMY, eyaml should do so too. This env var will skip loading the eyaml/ejson files during the rails environment loading so you don't end up with an error if you don't have keys set in your CI for example.

This can be handy for things like migrations/asset precompilation where secrets are not needed anyway.

See https://github.com/rails/rails/pull/46760 for the reason behind SECRET_KEY_BASE_DUMMY

Addresses https://github.com/cheddar-me/eyaml/issues/42